### PR TITLE
Encoding Error

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Sven Velt
+Copyright (c) 2009 Sven Velt
+Copyright (c) 2016 Olaf Lessenich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-mall Python script to download news from gmane to a mbox file
+Small Python script to download news from gmane to a mbox file
 
 Just run "./nntp2mbox $NEWSGROUP"
 

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -192,12 +192,15 @@ def main():
         return
 
     for group in args.groups:
-        download(group,
-                 args.aggressive,
-                 args.dry_run,
-                 args.number,
-                 args.start,
-                 args.update)
+        try:
+            download(group,
+                     args.aggressive,
+                     args.dry_run,
+                     args.number,
+                     args.start,
+                     args.update)
+        except:
+            pass
 
 
 if __name__ == "__main__":

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -108,7 +108,6 @@ def store(index, mbox, nntpconn, msgno, aggressive):
     number, msgid, msg = get(nntpconn, msgno, aggressive)
     mbox.add(msg)
     index_msg(index, msg)
-    index.commit()
     action = 'STORE'
     log('mbox', action, number, msgno, msgid)
 
@@ -227,9 +226,14 @@ def download(group, aggressive, dry_run, number=None, start=None, update=None):
             traceback.print_exc()
             pass
 
+        if count % 1000 == 0:
+            mbox.flush()
+            index.commit()
+
     if not dry_run:
         mbox.flush()
         mbox.unlock()
+        index.commit()
         index.close()
 
     nntpconn.quit()

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -57,7 +57,9 @@ def stat(nntpconn, msgno):
         else:
             break
     else:
-        print('%d: Failed to download after %d attempts' % (msgno, attempts))
+        print('%d: Failed to stat after %d attempts' % (msgno, attempts))
+        raise Exception('%d: Failed to stat after %d attempts'
+                        % (msgno, attempts))
 
     log('nntp', 'STAT', number, msgno, msgid)
     return number, msgid
@@ -76,6 +78,8 @@ def get(nntpconn, msgno, aggressive):
             break
     else:
         print('%d: Failed to download after %d attempts' % (msgno, attempts))
+        raise Exception('%d: Failed to download after %d attempts'
+                        % (msgno, attempts))
 
     text = str()
     for line in info.lines:
@@ -105,11 +109,15 @@ def check(index, mbox, nntpconn, msgno, update):
 
 
 def store(index, mbox, nntpconn, msgno, aggressive):
-    number, msgid, msg = get(nntpconn, msgno, aggressive)
-    mbox.add(msg)
-    index_msg(index, msg)
-    action = 'STORE'
-    log('mbox', action, number, msgno, msgid)
+    try:
+        number, msgid, msg = get(nntpconn, msgno, aggressive)
+        mbox.add(msg)
+        index_msg(index, msg)
+        action = 'STORE'
+        log('mbox', action, number, msgno, msgid)
+    except:
+        traceback.print_exc()
+        pass
 
 
 def index_msg(index, msg):

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -88,7 +88,10 @@ def get(nntpconn, msgno):
 def check(index, mbox, nntpconn, msgno, update):
 
     if update:
-                number, msgid = stat(nntpconn, msgno)
+        number, msgid = stat(nntpconn, msgno)
+    else:
+        number = msgno
+        msgid = 'unknown msg-id'
 
     if not update or not contains(index, msgid):
         queue = True

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -27,6 +27,16 @@ def log(target, action, number, msgno, msgid):
                                               msgno, msgid))
 
 
+def list_groups():
+    nntpconn = nntplib.NNTP('news.gmane.org')
+    resp, lists = nntpconn.list()
+
+    for group, last, first, flag in lists:
+        print(group)
+
+    nntpconn.quit()
+
+
 def contains(mbox, msgid):
     for m in mbox.itervalues():
         if m.get('Message-Id') == msgid:
@@ -130,6 +140,8 @@ def download(group, aggressive, dry_run, number=None, start=None, update=None):
         mbox.flush()
         mbox.unlock()
 
+    nntpconn.quit()
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -145,6 +157,10 @@ def main():
                         "--number",
                         help="Fetch the n most recent messages",
                         type=int)
+    parser.add_argument("-l",
+                        "--list-groups",
+                        help="list all available groups and exit",
+                        action="store_true")
     parser.add_argument("-s",
                         "--start",
                         help="First message in range",
@@ -153,8 +169,12 @@ def main():
                         "--update",
                         help="retrieve only new messages",
                         action="store_true")
-    parser.add_argument("groups", default="[]", nargs="+")
+    parser.add_argument("groups", default="[]", nargs="*")
     args = parser.parse_args()
+
+    if args.list_groups:
+        list_groups()
+        return
 
     for group in args.groups:
         download(group,

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -137,13 +137,15 @@ def download(group, aggressive, dry_run, number=None, start=None, update=None):
                 try:
                     store(mbox, nntpconn, msgno, update)
                 except nntplib.NNTPTemporaryError:
+                    print('%d: Temporary error. Sleep 5 seconds and retry.' %
+                          msgno)
                     time.sleep(5)
                     pass
                 else:
                     break
             else:
-                print('Failed to download msg nr %d after %d attempts' %
-                      (msgno, attempts))
+                print('%d: Failed to download after %d attempts' % (msgno,
+                                                                    attempts))
 
         except:
             print(sys.exc_info()[0])

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -63,7 +63,7 @@ def stat(nntpconn, msgno):
     return number, msgid
 
 
-def get(nntpconn, msgno):
+def get(nntpconn, msgno, aggressive):
     for attempt in range(attempts):
         try:
             resp, info = nntpconn.article(str(msgno))
@@ -104,8 +104,8 @@ def check(index, mbox, nntpconn, msgno, update):
     return queue
 
 
-def store(index, mbox, nntpconn, msgno):
-    number, msgid, msg = get(nntpconn, msgno)
+def store(index, mbox, nntpconn, msgno, aggressive):
+    number, msgid, msg = get(nntpconn, msgno, aggressive)
     mbox.add(msg)
     index_msg(index, msg)
     index.commit()
@@ -222,7 +222,7 @@ def download(group, aggressive, dry_run, number=None, start=None, update=None):
         msgno = stack.pop()
 
         try:
-            store(index, mbox, nntpconn, msgno)
+            store(index, mbox, nntpconn, msgno, aggressive)
         except:
             traceback.print_exc()
             pass

--- a/nntp2mbox.py
+++ b/nntp2mbox.py
@@ -1,59 +1,102 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+#
+# Distributed under terms of the MIT license.
+#
+# Copyright (c) 2009 Sven Velt
+#                    original code,
+#                    please see https://github.com/wAmpIre/nntp2mbox
+#                    for the original project by Sven
+#
+# Copyright (c) 2016 Olaf Lessenich
+#                    ported to python3, change in functionality
+#
 
+import argparse
+import email
+import mailbox
 import nntplib
 import sys
-import email
-
-outfile = file(sys.argv[-1], 'a')
-
-nntpconn = nntplib.NNTP('news.gmane.org')
-
-resp, count, first, last, name = nntpconn.group(sys.argv[-1])
-print 'Group', name, 'has', count, 'articles, range', first, 'to', last
-
-last = int(last)
-startnr = last - 500
-
-if startnr < 1:
-	startnr = 1
-
-try:
-	nofile = file(sys.argv[-1] + ".cfg", 'r')
-	startnr = int(nofile.readline())
-	nofile.close()
-except IOError:
-	print 'No number file found, starting at ' + str(startnr)
-
-if startnr < 1:
-	startnr = 1
-if startnr < last:
-	last = last +1
+import time
 
 
+def download(group, aggressive, dry_run, start=None):
+    """
+    The default behavior is to pause 30 seconds every 1000 messages while
+    downloading to reduce the load on the load on the gmane servers.
+    This can be skipped by supplying the aggressive flag.
+    """
+
+    mbox = mailbox.mbox(group + '.mbox')
+    mbox.lock()
+
+    nntpconn = nntplib.NNTP('news.gmane.org')
+
+    resp, count, first, last, name = nntpconn.group(group)
+    print(
+        'Group %s has %d articles, range %d to %d' %
+        (name, count, first, last))
+
+    last = int(last)
+
+    if start:
+        startnr = start
+
+        if startnr < first:
+            startnr = first
+
+        if startnr > last:
+            startnr = last
+
+    else:
+        startnr = first
+
+    if not start:
+        print('No start message provided, starting at %d' % startnr)
+
+    for msgno in range(startnr, last):
+        try:
+            if not aggressive and (msgno % 1000 == 0) and (msgno != startnr):
+                print('%d: Sleep 30 seconds' % msgno)
+                time.sleep(30)
+
+            if dry_run:
+                print('Dry-run: download message no. %d' % msgno)
+                pass
+
+            resp, info = nntpconn.article(str(msgno))
+
+            text = str()
+            for line in info.lines:
+                text += line.decode(encoding='UTF-8') + "\n"
+
+            msg = email.message_from_string(text)
+            mbox.add(msg)
+
+            print('%d(%s): %s' % (info.number, msgno, info.message_id))
+        except:
+            print(sys.exc_info()[0])
+            pass
+
+    mbox.flush()
+    mbox.unlock()
 
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a",
+                        "--aggressive",
+                        help="Disable waiting during a download",
+                        action="store_true")
+    parser.add_argument("-n",
+                        "--dry-run",
+                        help="perform a trial run with no changes made",
+                        action="store_true")
+    parser.add_argument("-s",
+                        "--start",
+                        help="First message in range",
+                        type=int)
+    parser.add_argument("groups", default="[]", nargs="+")
+    args = parser.parse_args()
 
-for msgno in range( startnr, last ):
-	try:
-		resp, number, id, list = nntpconn.article(str(msgno))
-
-		text = str()
-		for line in list:
-			text += line + "\n"
-
-		msg = email.message_from_string(text)
-		outfile.write(str(msg))
-		outfile.write('\n')
-
-		print '%s(%s): %s' % (number, msgno, id)
-	except:
-		pass
-
-outfile.close()
-
-
-nofile = file(sys.argv[-1] + ".cfg", 'w')
-nofile.write(str(last))
-nofile.close()
-
-
+    for group in args.groups:
+        download(group, args.aggressive, args.dry_run, args.start)


### PR DESCRIPTION
To fix the Encoding Error you can simply add the 'ignore' parameter in line 86 and change the encoding to 'ascii'.

But: The not parseable characters will be lost.

The line should look like: `text += (line.decode('ascii', 'ignore')) + "\n"`
